### PR TITLE
Expose more goconf methods through the Config interface.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ go:
   - 1.3
   - 1.4
   - 1.5
-  - 1.6
-  - tip
 
 install:
   - go get github.com/dlintw/goconf

--- a/config.go
+++ b/config.go
@@ -13,6 +13,9 @@ import (
 // GetXXXDefault methods return dflt if the named option in section has no
 // value. Use HasOption to determine the status of an option thus defaulted.
 type Config interface {
+	HasSection(section string) bool
+	GetSections() []string
+	GetOptions(section string) ([]string, error)
 	HasOption(section, option string) bool
 	GetBool(section, option string) (bool, error)
 	GetBoolDefault(section, option string, dflt bool) bool


### PR DESCRIPTION
This allows enumerating existing sections / options.