### PR TITLE
Add ConfigUpdater interface

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,16 @@ type Config interface {
 	GetStringDefault(section, option, dflt string) string
 }
 
+// ConfigUpdater provides access to the applications's configuration and allows
+// to update it.
+//
+// Update method takes a string mapping like [section][option]=value. Sections
+// are automatically created as needed and existing values are overwritten.
+type ConfigUpdater interface {
+	Config
+	Update(map[string]map[string]string) error
+}
+
 type config struct {
 	*conf.ConfigFile
 	path                string
@@ -113,6 +123,16 @@ func (config *config) DefaultOption(section, name, value string) {
 
 func (config *config) OverrideOption(section, name, value string) {
 	config.Overrides.AddOption(section, name, value)
+}
+
+func (config *config) Update(updates map[string]map[string]string) error {
+	for section, options := range updates {
+		for option, value := range options {
+			config.ConfigFile.AddOption(section, option, value)
+		}
+	}
+
+	return nil
 }
 
 func (config *config) load() (err error) {

--- a/container.go
+++ b/container.go
@@ -35,7 +35,7 @@ type Metadata interface {
 //
 // Typically subinterfaces should be used when possible.
 type Container interface {
-	Config
+	ConfigUpdater
 	Logger
 	Metadata
 }


### PR DESCRIPTION
To be able to support dynamic configuration providers, an ConfigUpdater interface defines the Update function which can be used to change/extend a loaded static configuration. The Container interface was changed to use the ConfigUpdater interface so the Update function is available in normal runtime callbacks.
